### PR TITLE
make browser startup optional

### DIFF
--- a/packages/wheelhouse/src/developmentActions.js
+++ b/packages/wheelhouse/src/developmentActions.js
@@ -24,8 +24,10 @@ export const developmentStart = script => async (dispatch, getState) => {
       dispatch(packagesRun(pkgName, true));
     }
   });
-  const port = getState().config.port;
-  opn(`http://localhost:${port}/#/`);
+  if (!(getState().config.openBrowserOnStartup && getState().config.openBrowserOnStartup === false)) {
+    const port = getState().config.port;
+    opn(`http://localhost:${port}/#/`);
+  }
   dispatch(kubernetesStartPullingData());
 };
 

--- a/packages/wheelhouse/src/developmentActions.js
+++ b/packages/wheelhouse/src/developmentActions.js
@@ -10,6 +10,10 @@ import { generateUid } from "./util/uid";
 import { packagesInstall, packagesLink, packagesRun } from "./packagesActions";
 import { run } from "./util/run";
 
+function isExplicitlyFalse(val) {
+  return typeof val !== "undefined" && val === false;
+}
+
 export const developmentStart = script => async (dispatch, getState) => {
   await dispatch(configLoad());
   await dispatch(serverStart());
@@ -24,7 +28,7 @@ export const developmentStart = script => async (dispatch, getState) => {
       dispatch(packagesRun(pkgName, true));
     }
   });
-  if (!(getState().config.openBrowserOnStartup && getState().config.openBrowserOnStartup === false)) {
+  if (!isExplicitlyFalse(getState().config.openBrowserOnStartup)) {
     const port = getState().config.port;
     opn(`http://localhost:${port}/#/`);
   }


### PR DESCRIPTION
I'm restarting wheelhouse many times in the span of a workday, and it opens a new browser window/tab every time. This makes it optional but preserves the current behavior as the default for folks that are used to it.

Personally, I prefer a different default:

1. don't call `opn()`
1. wheelhouse web UI url is logged to the console (I can just click the link in my console if/when I want to)